### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/poetry-package.yml
+++ b/.github/workflows/poetry-package.yml
@@ -1,4 +1,6 @@
 name: Python package
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/meetbryce/open-source-slack-ai/security/code-scanning/1](https://github.com/meetbryce/open-source-slack-ai/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out the repository and publishing a package to PyPI, the `contents: read` permission is sufficient for repository access, and no additional permissions are required for the `GITHUB_TOKEN`. The `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
